### PR TITLE
Add supporter user filters

### DIFF
--- a/src/app/admin/[[...slug]]/page.tsx
+++ b/src/app/admin/[[...slug]]/page.tsx
@@ -207,6 +207,8 @@ export default function AdminPage() {
     const [auditLog, setAuditLog] = useState<any[]>([]);
 
     // Filters
+    const [userSupporterFilter, setUserSupporterFilter] = useState<'all' | 'supporters' | 'non_supporters'>('all');
+    const [userSortMode, setUserSortMode] = useState<'supporters_first' | 'newest' | 'oldest' | 'name_asc'>('supporters_first');
     const [challengeCityFilter, setChallengeCityFilter] = useState('');
     const [challengeDateFrom, setChallengeDateFrom] = useState('');
     const [challengeDateTo, setChallengeDateTo] = useState('');
@@ -345,6 +347,14 @@ export default function AdminPage() {
                 case 'users':
                     query = supabase.from('profiles').select('*');
                     countQuery = supabase.from('profiles').select('*', { count: 'exact', head: true });
+                    if (userSupporterFilter === 'supporters') {
+                        query = query.eq('is_supporter', true);
+                        countQuery = countQuery.eq('is_supporter', true);
+                    } else if (userSupporterFilter === 'non_supporters') {
+                        // Older profiles may predate the boolean default and contain NULL.
+                        query = query.or('is_supporter.eq.false,is_supporter.is.null');
+                        countQuery = countQuery.or('is_supporter.eq.false,is_supporter.is.null');
+                    }
                     break;
                 case 'parking':
                     query = supabase.from('parkingSpots').select('*');
@@ -551,9 +561,23 @@ export default function AdminPage() {
                 community_routes: ['created_at', 'status', 'name', 'quality_rating'],
                 audit_log: ['created_at', 'action', 'target_type'],
             };
-            const allowed = validSortKeys[activeTab] || ['created_at'];
-            const sortKeyForTab = allowed.includes(sortConfig.key) ? sortConfig.key : allowed[0];
-            query = query.order(sortKeyForTab, { ascending: sortConfig.direction === 'asc' });
+            if (activeTab === 'users') {
+                if (userSortMode === 'supporters_first') {
+                    query = query
+                        .order('is_supporter', { ascending: false, nullsFirst: false })
+                        .order('created_at', { ascending: false });
+                } else if (userSortMode === 'oldest') {
+                    query = query.order('created_at', { ascending: true });
+                } else if (userSortMode === 'name_asc') {
+                    query = query.order('username', { ascending: true, nullsFirst: false });
+                } else {
+                    query = query.order('created_at', { ascending: false });
+                }
+            } else {
+                const allowed = validSortKeys[activeTab] || ['created_at'];
+                const sortKeyForTab = allowed.includes(sortConfig.key) ? sortConfig.key : allowed[0];
+                query = query.order(sortKeyForTab, { ascending: sortConfig.direction === 'asc' });
+            }
             }
 
             // Pagination
@@ -734,12 +758,12 @@ export default function AdminPage() {
     useEffect(() => {
         fetchData();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [activeTab, currentPage, sortConfig, searchTerm, profile, pageSize, challengeCityFilter, challengeDateFrom, challengeDateTo, challengeActiveFilter, routeStatusFilter, routeDateFrom, routeDateTo, auditActionFilter, auditTargetTypeFilter, feedbackStatusFilter, feedbackPriorityFilter, feedbackCategoryFilter, poiFlagStatusFilter, poiFlagReasonFilter, poiSuggestionStatusFilter, poiSuggestionTypeFilter, parkingImageStatusFilter]);
+    }, [activeTab, currentPage, sortConfig, searchTerm, profile, pageSize, userSupporterFilter, userSortMode, challengeCityFilter, challengeDateFrom, challengeDateTo, challengeActiveFilter, routeStatusFilter, routeDateFrom, routeDateTo, auditActionFilter, auditTargetTypeFilter, feedbackStatusFilter, feedbackPriorityFilter, feedbackCategoryFilter, poiFlagStatusFilter, poiFlagReasonFilter, poiSuggestionStatusFilter, poiSuggestionTypeFilter, parkingImageStatusFilter]);
 
     useEffect(() => {
         setSelectedRows(new Set());
         setSelectAll(false);
-    }, [currentPage, pageSize, feedbackStatusFilter, feedbackPriorityFilter, feedbackCategoryFilter, poiFlagStatusFilter, poiFlagReasonFilter]);
+    }, [currentPage, pageSize, userSupporterFilter, userSortMode, feedbackStatusFilter, feedbackPriorityFilter, feedbackCategoryFilter, poiFlagStatusFilter, poiFlagReasonFilter]);
 
     // Load cities for filter dropdowns when those tabs open
     useEffect(() => {
@@ -1611,13 +1635,21 @@ export default function AdminPage() {
                                             selectedRows={selectedRows}
                                             onSelectAll={handleSelectAll}
                                             onSelectRow={handleSelectRow}
-                                            onSort={handleSort}
-                                            sortConfig={sortConfig}
                                             onRowClick={(item) => openFreshDetail(item, 'user')}
                                             onToggleBan={handleUserToggleBan}
                                             onToggleSupporter={handleUserToggleSupporter}
                                             toggleLoading={toggleLoading}
                                             searchTerm={searchTerm}
+                                            supporterFilter={userSupporterFilter}
+                                            onSupporterFilterChange={(value) => {
+                                                setUserSupporterFilter(value);
+                                                setCurrentPage(1);
+                                            }}
+                                            sortMode={userSortMode}
+                                            onSortModeChange={(value) => {
+                                                setUserSortMode(value);
+                                                setCurrentPage(1);
+                                            }}
                                             currentPage={currentPage}
                                             totalPages={totalPages}
                                             onPageChange={setCurrentPage}

--- a/src/components/admin/UsersTable.tsx
+++ b/src/components/admin/UsersTable.tsx
@@ -25,14 +25,16 @@ interface UsersTableProps {
     selectedRows: Set<string>;
     onSelectAll: (checked: boolean) => void;
     onSelectRow: (id: string, checked: boolean) => void;
-    onSort: (key: string) => void;
-    sortConfig: { key: string; direction: string };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onRowClick: (item: any) => void;
     onToggleBan?: (id: string, currentlyBanned: boolean) => void;
     onToggleSupporter?: (id: string, currentlySupporter: boolean) => void;
     toggleLoading?: string | null;
     searchTerm?: string;
+    supporterFilter: 'all' | 'supporters' | 'non_supporters';
+    onSupporterFilterChange: (value: 'all' | 'supporters' | 'non_supporters') => void;
+    sortMode: 'supporters_first' | 'newest' | 'oldest' | 'name_asc';
+    onSortModeChange: (value: 'supporters_first' | 'newest' | 'oldest' | 'name_asc') => void;
     currentPage: number;
     totalPages: number;
     onPageChange: (page: number) => void;
@@ -45,13 +47,15 @@ export default function UsersTable({
     // selectedRows,
     // onSelectAll,
     // onSelectRow,
-    // onSort,
-    // sortConfig,
     onRowClick,
     onToggleBan,
     onToggleSupporter,
     toggleLoading,
     searchTerm,
+    supporterFilter,
+    onSupporterFilterChange,
+    sortMode,
+    onSortModeChange,
     // selectAll,
     currentPage,
     totalPages,
@@ -59,26 +63,50 @@ export default function UsersTable({
     pageSize,
     onPageSizeChange,
 }: UsersTableProps) {
-    if (users.length === 0) {
-        return (
-            <div className="flex flex-col items-center justify-center py-32 border-2 border-dashed border-zinc-800 rounded-3xl bg-zinc-900/20">
-                <div className="w-16 h-16 rounded-full bg-zinc-900 flex items-center justify-center mb-4">
-                    <Users className="w-8 h-8 text-zinc-700" />
-                </div>
-                <h3 className="text-lg font-semibold text-white">
-                    {searchTerm ? 'Nincs találat' : 'Nincsenek felhasználók'}
-                </h3>
-                <p className="text-zinc-500 max-w-xs text-center mt-2">
-                    {searchTerm
-                        ? 'Próbálj meg más keresési kifejezést használni.'
-                        : 'Még nem regisztrált senki az alkalmazásba.'}
-                </p>
-            </div>
-        );
-    }
-
     return (
-        <div className="flex flex-col gap-4 h-full">
+        <section className="flex h-full min-h-0 flex-col" aria-label="Felhasználók">
+            <div className="ops-filterbar">
+                <label className="ops-filter">
+                    <strong>Támogató</strong>
+                    <select
+                        value={supporterFilter}
+                        onChange={(event) => onSupporterFilterChange(event.target.value as 'all' | 'supporters' | 'non_supporters')}
+                    >
+                        <option value="all">Mind</option>
+                        <option value="supporters">Csak támogatók</option>
+                        <option value="non_supporters">Nem támogatók</option>
+                    </select>
+                </label>
+                <label className="ops-filter">
+                    <strong>Rendezés</strong>
+                    <select
+                        value={sortMode}
+                        onChange={(event) => onSortModeChange(event.target.value as 'supporters_first' | 'newest' | 'oldest' | 'name_asc')}
+                    >
+                        <option value="supporters_first">Támogatók elöl</option>
+                        <option value="newest">Legújabb elöl</option>
+                        <option value="oldest">Legrégebbi elöl</option>
+                        <option value="name_asc">Név szerint A–Z</option>
+                    </select>
+                </label>
+            </div>
+
+            {users.length === 0 ? (
+                <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
+                    <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-zinc-900">
+                        <Users className="h-8 w-8 text-zinc-700" />
+                    </div>
+                    <h3 className="text-lg font-semibold text-white">
+                        {searchTerm || supporterFilter !== 'all' ? 'Nincs találat' : 'Nincsenek felhasználók'}
+                    </h3>
+                    <p className="mt-2 max-w-xs text-zinc-500">
+                        {searchTerm || supporterFilter !== 'all'
+                            ? 'Próbálj más keresést vagy támogatói szűrést.'
+                            : 'Még nem regisztrált senki az alkalmazásba.'}
+                    </p>
+                </div>
+            ) : (
+            <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
             <div className="flex-1 overflow-auto min-h-0 rounded-xl border border-white/5 bg-[#111111]">
                 <table className="w-full text-left border-collapse">
                     <thead className="sticky top-0 z-10 bg-[#111111]">
@@ -262,6 +290,8 @@ export default function UsersTable({
                     </div>
                 )}
             </div>
-        </div>
+            </div>
+            )}
+        </section>
     );
 }


### PR DESCRIPTION
## What changed

- add supporter-status filtering to the admin user list
- default user sorting to supporters first, with newest, oldest, and A-Z alternatives
- apply filters and ordering server-side before pagination
- keep filter controls available when no users match

## Why

Admins could grant supporter status, but could not isolate supporters or reliably place them at the top of the user list.

## Impact

The Users admin screen now makes supporter accounts immediately discoverable while preserving accurate result counts and pagination.

## Validation

- `npx eslint 'src/app/admin/[[...slug]]/page.tsx' 'src/components/admin/UsersTable.tsx'`
- `npx tsc --noEmit`
- `npm run build`
- live database ordering check: 0 non-supporters misplaced in the supporter-first group
